### PR TITLE
Escape Special Characters

### DIFF
--- a/Sources/SwiftCodeGenerator.swift
+++ b/Sources/SwiftCodeGenerator.swift
@@ -74,6 +74,7 @@ private extension Localisation {
         let formattedComment = comment?.components(separatedBy: .newlines).joined(separator: " ")
         let defaultLanguageValue = self.defaultLanguageValue?
             .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\"", with: "\\\"")
         let localizedStringParameters = [
             "\"\(key)\"",
             "tableName: \"\(tableName)\"",

--- a/Sources/SwiftCodeGenerator.swift
+++ b/Sources/SwiftCodeGenerator.swift
@@ -72,6 +72,8 @@ private extension Localisation {
     var swiftRepresentation: String {
         let symbolName = (key.components(separatedBy: ".").last ?? key).camelCased()
         let formattedComment = comment?.components(separatedBy: .newlines).joined(separator: " ")
+        let defaultLanguageValue = self.defaultLanguageValue?
+            .replacingOccurrences(of: "\n", with: "\\n")
         let localizedStringParameters = [
             "\"\(key)\"",
             "tableName: \"\(tableName)\"",
@@ -157,7 +159,7 @@ private extension Localisation.Placeholder.DataType {
 
 private extension Localisation.Preview {
     var documentationComment: String {
-        let valueComment = "/// \(value)"
+        let valueComment = "/// \(value.replacingOccurrences(of: "\n", with: " "))"
         guard let description else {
             return valueComment
         }

--- a/Tests/SwiftCodeGeneratorTests.swift
+++ b/Tests/SwiftCodeGeneratorTests.swift
@@ -309,6 +309,30 @@ private final class DJAStringsBundleClass {}
 """
         XCTAssertEqual(vendedSwiftCode, expectedOutput)
     }
+    
+    func testItGeneratesTheCorrectOutputForLocalisationsWithDefaultValuesContainingNewlines() throws {
+        givenASwiftCodeGenerator(withRootLocalisationsTreeNode: TestLocalisationsTreeNode(name: "Root",
+                                                                                          localisations: [
+                                                                                            Localisation(key: "localisation", tableName: "Localizable", defaultLanguageValue: "I contain a\nnewline character.", comment: nil, placeholders: [], previews: [
+                                                                                                Localisation.Preview(description: nil, value: "Localised")
+                                                                                            ])
+                                                                                          ],
+                                                                                          childNodes: []))
+        try whenSwiftCodeIsVended()
+        let expectedOutput =
+        """
+import Foundation
+
+public enum Root {
+    /// Localised
+    static let localisation = NSLocalizedString("localisation", tableName: "Localizable", bundle: Bundle(for: DJAStringsBundleClass.self), value: "I contain a\\nnewline character.", comment: "")
+}
+
+private final class DJAStringsBundleClass {}
+
+"""
+        XCTAssertEqual(vendedSwiftCode, expectedOutput)
+    }
 }
 
 // MARK: - Comment Parameter
@@ -471,6 +495,30 @@ public enum Root {
     /// **Comment**
     /// I have multiple previews
     static let localisation = NSLocalizedString("localisation", tableName: "Localizable", bundle: Bundle(for: DJAStringsBundleClass.self), comment: "I have multiple previews")
+}
+
+private final class DJAStringsBundleClass {}
+
+"""
+        XCTAssertEqual(vendedSwiftCode, expectedOutput)
+    }
+    
+    func testItProducesTheCorrectDocumentationCommentsForLocalisationsWithPreviewsContainingNewlines() throws {
+        givenASwiftCodeGenerator(withRootLocalisationsTreeNode: TestLocalisationsTreeNode(name: "Root",
+                                                                                          localisations: [
+                                                                                            Localisation(key: "localisation", tableName: "Localizable", defaultLanguageValue: nil, comment: nil, placeholders: [], previews: [
+                                                                                                Localisation.Preview(description: nil, value: "Value\n\nOne")
+                                                                                            ])
+                                                                                          ],
+                                                                                          childNodes: []))
+        try whenSwiftCodeIsVended()
+        let expectedOutput =
+        """
+import Foundation
+
+public enum Root {
+    /// Value  One
+    static let localisation = NSLocalizedString("localisation", tableName: "Localizable", bundle: Bundle(for: DJAStringsBundleClass.self), comment: "")
 }
 
 private final class DJAStringsBundleClass {}

--- a/Tests/SwiftCodeGeneratorTests.swift
+++ b/Tests/SwiftCodeGeneratorTests.swift
@@ -333,6 +333,30 @@ private final class DJAStringsBundleClass {}
 """
         XCTAssertEqual(vendedSwiftCode, expectedOutput)
     }
+    
+    func testItGeneratesTheCorrectOutputForLocalisationsWithDefaultValuesContainingQuotationMarks() throws {
+        givenASwiftCodeGenerator(withRootLocalisationsTreeNode: TestLocalisationsTreeNode(name: "Root",
+                                                                                          localisations: [
+                                                                                            Localisation(key: "localisation", tableName: "Localizable", defaultLanguageValue: "I contain \"quotation marks\".", comment: nil, placeholders: [], previews: [
+                                                                                                Localisation.Preview(description: nil, value: "Localised")
+                                                                                            ])
+                                                                                          ],
+                                                                                          childNodes: []))
+        try whenSwiftCodeIsVended()
+        let expectedOutput =
+        """
+import Foundation
+
+public enum Root {
+    /// Localised
+    static let localisation = NSLocalizedString("localisation", tableName: "Localizable", bundle: Bundle(for: DJAStringsBundleClass.self), value: "I contain \\"quotation marks\\".", comment: "")
+}
+
+private final class DJAStringsBundleClass {}
+
+"""
+        XCTAssertEqual(vendedSwiftCode, expectedOutput)
+    }
 }
 
 // MARK: - Comment Parameter


### PR DESCRIPTION
This prevents newlines and quotation marks in default language values and documentation comments from breaking the generated Swift output.