### PR TITLE
Use NSLocalizedString for Automatically Extracted Strings

### DIFF
--- a/Sources/Localisation.swift
+++ b/Sources/Localisation.swift
@@ -22,6 +22,9 @@ struct Localisation: Equatable {
     /// will return `nil` for this property.
     let defaultLanguageValue: String?
     
+    /// The extraction state of the localisation, if any.
+    let extractionState: ExtractionState?
+    
     /// The comment assigned to the localisation, if any.
     let comment: String?
     
@@ -33,6 +36,30 @@ struct Localisation: Equatable {
     /// have a single preview, whereas localisations with plural or width
     /// variations will have a preview for each variation.
     let previews: [Preview]
+}
+
+// MARK: - Localisation.ExtractionState
+
+extension Localisation {
+    /// The different extraction states for a string localisation.
+    enum ExtractionState {
+        
+        /// The string was migrated from a legacy strings file or strings
+        /// dict.
+        case migrated
+        
+        /// The string was extracted manually i.e was entered directly in to
+        /// the `.xcstrings` file.
+        case manual
+        
+        /// The string was extracted automatically by Xcode from usage of
+        /// `NSLocalizedStringWithDefaultValue`, or from a XIB file.
+        case extractedWithValue
+        
+        /// The string was extracted automatically by Xcode, but has since
+        /// been modified in the location from which it was extracted.
+        case stale
+    }
 }
 
 // MARK: - Localisation.Placeholder

--- a/Sources/LocalisationGroup.swift
+++ b/Sources/LocalisationGroup.swift
@@ -76,11 +76,29 @@ private extension Localisation {
         }
         self.key = key
         self.tableName = tableName
+        extractionState = ExtractionState(documentExtractionState: documentLocalisation.extractionState)
         comment = documentLocalisation.comment
         let sourceLanguageLocalisation = documentLocalisation.localisations?[sourceLanguage]
         defaultLanguageValue = sourceLanguageLocalisation?.defaultLanguageValue
         placeholders = try sourceLanguageLocalisation?.placeholders ?? []
         previews = try sourceLanguageLocalisation?.previews ?? []
+    }
+}
+
+private extension Localisation.ExtractionState {
+    init?(documentExtractionState: XCStringsDocument.StringLocalisation.ExtractionState?) {
+        switch documentExtractionState {
+        case .migrated:
+            self = .migrated
+        case .manual:
+            self = .manual
+        case .extractedWithValue:
+            self = .extractedWithValue
+        case .stale:
+            self = .stale
+        case nil:
+            return nil
+        }
     }
 }
 

--- a/Sources/SwiftCodeGenerator.swift
+++ b/Sources/SwiftCodeGenerator.swift
@@ -85,7 +85,7 @@ private extension Localisation {
             defaultLanguageValue != nil ? " value: \"\(defaultLanguageValue!)\"" : nil,
             "comment: \"\(formattedComment ?? "")\""
         ]
-        let localizedStringFunctionCall = "DJALocalizedString(\(localizedStringParameters.compactMap { $0 }.joined(separator: ", ")))"
+        let localizedStringFunctionCall = "\(extractionState.localizedStringFunctionName)(\(localizedStringParameters.compactMap { $0 }.joined(separator: ", ")))"
         if placeholders.isEmpty {
             return """
 \(documentationComment(withLocalisationComment: formattedComment))
@@ -137,6 +137,17 @@ static func \(symbolName)(\(placeholderFunctionParameters)) -> String {
                 return parameterName
             }
         }.joined(separator: ", ")
+    }
+}
+
+private extension Optional where Wrapped == Localisation.ExtractionState {
+    var localizedStringFunctionName: String {
+        switch self {
+        case .migrated, .manual, .stale:
+            return "DJALocalizedString"
+        case .extractedWithValue, .none:
+            return "NSLocalizedString"
+        }
     }
 }
 

--- a/Tests/SwiftCodeGeneratorTests.swift
+++ b/Tests/SwiftCodeGeneratorTests.swift
@@ -32,7 +32,7 @@ extension SwiftCodeGeneratorTests {
     func testItProducesTheCorrectOutputForASingleNodeWithOneLocalisation() throws {
         givenASwiftCodeGenerator(withRootLocalisationsTreeNode: TestLocalisationsTreeNode(name: "Root",
                                                                                           localisations: [
-                                                                                            Localisation(key: "localisation", tableName: "Localizable", defaultLanguageValue: nil, comment: nil, placeholders: [], previews: [
+                                                                                            Localisation(key: "localisation", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .manual, comment: nil, placeholders: [], previews: [
                                                                                                 Localisation.Preview(description: nil, value: "Localised")
                                                                                             ])
                                                                                           ],
@@ -60,10 +60,10 @@ private func DJALocalizedString(_ key: String, tableName: String? = nil, value: 
     func testItProducesTheCorrectOutputForASingleNodeWithMultipleLocalisations() throws {
         givenASwiftCodeGenerator(withRootLocalisationsTreeNode: TestLocalisationsTreeNode(name: "Root",
                                                                                           localisations: [
-                                                                                            Localisation(key: "localisation_one", tableName: "Localizable", defaultLanguageValue: nil, comment: nil, placeholders: [], previews: [
+                                                                                            Localisation(key: "localisation_one", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .manual, comment: nil, placeholders: [], previews: [
                                                                                                 Localisation.Preview(description: nil, value: "Localised One")
                                                                                             ]),
-                                                                                            Localisation(key: "localisation_two", tableName: "Localizable", defaultLanguageValue: nil, comment: nil, placeholders: [], previews: [
+                                                                                            Localisation(key: "localisation_two", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .manual, comment: nil, placeholders: [], previews: [
                                                                                                 Localisation.Preview(description: nil, value: "Localised Two")
                                                                                             ])
                                                                                           ],
@@ -97,27 +97,27 @@ private func DJALocalizedString(_ key: String, tableName: String? = nil, value: 
                                                                                           childNodes: [
                                                                                             TestLocalisationsTreeNode(name: "child_one",
                                                                                                                       localisations: [
-                                                                                                                        Localisation(key: "child_one.one", tableName: "Localizable", defaultLanguageValue: nil, comment: nil, placeholders: [], previews: [
+                                                                                                                        Localisation(key: "child_one.one", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .manual, comment: nil, placeholders: [], previews: [
                                                                                                                             Localisation.Preview(description: nil, value: "Child One One")
                                                                                                                         ]),
-                                                                                                                        Localisation(key: "child_one.two", tableName: "Localizable", defaultLanguageValue: nil, comment: nil, placeholders: [Localisation.Placeholder(name: nil, type: .object)], previews: [
+                                                                                                                        Localisation(key: "child_one.two", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .manual, comment: nil, placeholders: [Localisation.Placeholder(name: nil, type: .object)], previews: [
                                                                                                                             Localisation.Preview(description: nil, value: "Child One Two")
                                                                                                                         ])
                                                                                                                       ],
                                                                                                                       childNodes: []),
                                                                                             TestLocalisationsTreeNode(name: "child_two",
                                                                                                                       localisations: [
-                                                                                                                        Localisation(key: "child_two.one", tableName: "Localizable", defaultLanguageValue: nil, comment: nil, placeholders: [], previews: [
+                                                                                                                        Localisation(key: "child_two.one", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .manual, comment: nil, placeholders: [], previews: [
                                                                                                                             Localisation.Preview(description: nil, value: "Child Two One")
                                                                                                                         ]),
-                                                                                                                        Localisation(key: "child_two.two", tableName: "Localizable", defaultLanguageValue: nil, comment: nil, placeholders: [Localisation.Placeholder(name: "message_count", type: .integer)], previews: [
+                                                                                                                        Localisation(key: "child_two.two", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .manual, comment: nil, placeholders: [Localisation.Placeholder(name: "message_count", type: .integer)], previews: [
                                                                                                                             Localisation.Preview(description: nil, value: "Child Two Two")
                                                                                                                         ])
                                                                                                                       ],
                                                                                                                       childNodes: [
                                                                                                                         TestLocalisationsTreeNode(name: "nested_child",
                                                                                                                                                   localisations: [
-                                                                                                                                                    Localisation(key: "child_two.nested_child.one", tableName: "Localizable", defaultLanguageValue: nil, comment: nil, placeholders: [], previews: [
+                                                                                                                                                    Localisation(key: "child_two.nested_child.one", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .manual, comment: nil, placeholders: [], previews: [
                                                                                                                                                         Localisation.Preview(description: nil, value: "Child Two Nested One")
                                                                                                                                                     ])
                                                                                                                                                   ],
@@ -169,37 +169,37 @@ private func DJALocalizedString(_ key: String, tableName: String? = nil, value: 
     func testItProducesTheCorrectOutputForASingleNodeWithMultipleLocalisationsAndMultipleChildNodes() throws {
         givenASwiftCodeGenerator(withRootLocalisationsTreeNode: TestLocalisationsTreeNode(name: "Root",
                                                                                           localisations: [
-                                                                                            Localisation(key: "localisation_one", tableName: "Localizable", defaultLanguageValue: nil, comment: nil, placeholders: [], previews: [
+                                                                                            Localisation(key: "localisation_one", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .manual, comment: nil, placeholders: [], previews: [
                                                                                                 Localisation.Preview(description: nil, value: "Localisation One")
                                                                                             ]),
-                                                                                            Localisation(key: "localisation_two", tableName: "Localizable", defaultLanguageValue: nil, comment: nil, placeholders: [], previews: [
+                                                                                            Localisation(key: "localisation_two", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .manual, comment: nil, placeholders: [], previews: [
                                                                                                 Localisation.Preview(description: nil, value: "Localisation Two")
                                                                                             ])
                                                                                           ],
                                                                                           childNodes: [
                                                                                             TestLocalisationsTreeNode(name: "child_one",
                                                                                                                       localisations: [
-                                                                                                                        Localisation(key: "child_one.one", tableName: "Localizable", defaultLanguageValue: nil, comment: nil, placeholders: [], previews: [
+                                                                                                                        Localisation(key: "child_one.one", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .manual, comment: nil, placeholders: [], previews: [
                                                                                                                             Localisation.Preview(description: nil, value: "Child One One")
                                                                                                                         ]),
-                                                                                                                        Localisation(key: "child_one.two", tableName: "Localizable", defaultLanguageValue: nil, comment: nil, placeholders: [Localisation.Placeholder(name: nil, type: .object)], previews: [
+                                                                                                                        Localisation(key: "child_one.two", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .manual, comment: nil, placeholders: [Localisation.Placeholder(name: nil, type: .object)], previews: [
                                                                                                                             Localisation.Preview(description: nil, value: "Child One Two")
                                                                                                                         ])
                                                                                                                       ],
                                                                                                                       childNodes: []),
                                                                                             TestLocalisationsTreeNode(name: "child_two",
                                                                                                                       localisations: [
-                                                                                                                        Localisation(key: "child_two.one", tableName: "Localizable", defaultLanguageValue: nil, comment: nil, placeholders: [], previews: [
+                                                                                                                        Localisation(key: "child_two.one", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .manual, comment: nil, placeholders: [], previews: [
                                                                                                                             Localisation.Preview(description: nil, value: "Child Two One")
                                                                                                                         ]),
-                                                                                                                        Localisation(key: "child_two.two", tableName: "Localizable", defaultLanguageValue: nil, comment: nil, placeholders: [Localisation.Placeholder(name: "message_count", type: .integer)], previews: [
+                                                                                                                        Localisation(key: "child_two.two", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .manual, comment: nil, placeholders: [Localisation.Placeholder(name: "message_count", type: .integer)], previews: [
                                                                                                                             Localisation.Preview(description: nil, value: "Child Two Two")
                                                                                                                         ])
                                                                                                                       ],
                                                                                                                       childNodes: [
                                                                                                                         TestLocalisationsTreeNode(name: "nested_child",
                                                                                                                                                   localisations: [
-                                                                                                                                                    Localisation(key: "child_two.nested_child.one", tableName: "Localizable", defaultLanguageValue: nil, comment: nil, placeholders: [], previews: [
+                                                                                                                                                    Localisation(key: "child_two.nested_child.one", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .manual, comment: nil, placeholders: [], previews: [
                                                                                                                                                         Localisation.Preview(description: nil, value: "Child Two Nested One")
                                                                                                                                                     ])
                                                                                                                                                   ],
@@ -255,7 +255,7 @@ private func DJALocalizedString(_ key: String, tableName: String? = nil, value: 
     }
     
     func testItProducesTheCorrectOutputForDeeplyNestedChildNodes() throws {
-        let childThree = TestLocalisationsTreeNode(name: "child_three", localisations: [Localisation(key: "child_one.child_two.child_three.one", tableName: "Localizable", defaultLanguageValue: nil, comment: nil, placeholders: [], previews: [Localisation.Preview(description: nil, value: "Child Three")])], childNodes: [])
+        let childThree = TestLocalisationsTreeNode(name: "child_three", localisations: [Localisation(key: "child_one.child_two.child_three.one", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .manual, comment: nil, placeholders: [], previews: [Localisation.Preview(description: nil, value: "Child Three")])], childNodes: [])
         let childTwo = TestLocalisationsTreeNode(name: "child_two", localisations: [], childNodes: [childThree])
         let childOne = TestLocalisationsTreeNode(name: "child_one", localisations: [], childNodes: [childTwo])
         givenASwiftCodeGenerator(withRootLocalisationsTreeNode: TestLocalisationsTreeNode(name: "Root",
@@ -290,19 +290,163 @@ private func DJALocalizedString(_ key: String, tableName: String? = nil, value: 
     }
 }
 
+// MARK: - LocalizedString Function Selection
+
+extension SwiftCodeGeneratorTests {
+    func testItUsesTheCorrectLocalizedStringFunctionForStringsWithTheMigratedExtractionState() throws {
+        givenASwiftCodeGenerator(withRootLocalisationsTreeNode: TestLocalisationsTreeNode(name: "Root",
+                                                                                          localisations: [
+                                                                                            Localisation(key: "Migrated", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .migrated, comment: nil, placeholders: [], previews: [
+                                                                                                Localisation.Preview(description: nil, value: "Localised")
+                                                                                            ])
+                                                                                          ],
+                                                                                          childNodes: []))
+        try whenSwiftCodeIsVended()
+        let expectedOutput =
+        """
+import Foundation
+
+public enum Root {
+    /// Localised
+    static let migrated = DJALocalizedString("Migrated", tableName: "Localizable", comment: "")
+}
+
+private final class DJAStringsBundleClass {}
+
+private func DJALocalizedString(_ key: String, tableName: String? = nil, value: String = "", comment: String) -> String {
+    NSLocalizedString(key, tableName: tableName, bundle: Bundle(for: DJAStringsBundleClass.self), value: value, comment: comment)
+}
+
+"""
+        XCTAssertEqual(vendedSwiftCode, expectedOutput)
+    }
+    
+    func testItUsesTheCorrectLocalizedStringFunctionForStringsWithTheManualExtractionState() throws {
+        givenASwiftCodeGenerator(withRootLocalisationsTreeNode: TestLocalisationsTreeNode(name: "Root",
+                                                                                          localisations: [
+                                                                                            Localisation(key: "Manual", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .manual, comment: nil, placeholders: [], previews: [
+                                                                                                Localisation.Preview(description: nil, value: "Localised")
+                                                                                            ])
+                                                                                          ],
+                                                                                          childNodes: []))
+        try whenSwiftCodeIsVended()
+        let expectedOutput =
+        """
+import Foundation
+
+public enum Root {
+    /// Localised
+    static let manual = DJALocalizedString("Manual", tableName: "Localizable", comment: "")
+}
+
+private final class DJAStringsBundleClass {}
+
+private func DJALocalizedString(_ key: String, tableName: String? = nil, value: String = "", comment: String) -> String {
+    NSLocalizedString(key, tableName: tableName, bundle: Bundle(for: DJAStringsBundleClass.self), value: value, comment: comment)
+}
+
+"""
+        XCTAssertEqual(vendedSwiftCode, expectedOutput)
+    }
+    
+    func testItUsesTheCorrectLocalizedStringFunctionForStringsWithTheExtractedWithValueExtractionState() throws {
+        givenASwiftCodeGenerator(withRootLocalisationsTreeNode: TestLocalisationsTreeNode(name: "Root",
+                                                                                          localisations: [
+                                                                                            Localisation(key: "Extracted", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .extractedWithValue, comment: nil, placeholders: [], previews: [
+                                                                                                Localisation.Preview(description: nil, value: "Localised")
+                                                                                            ])
+                                                                                          ],
+                                                                                          childNodes: []))
+        try whenSwiftCodeIsVended()
+        let expectedOutput =
+        """
+import Foundation
+
+public enum Root {
+    /// Localised
+    static let extracted = NSLocalizedString("Extracted", tableName: "Localizable", comment: "")
+}
+
+private final class DJAStringsBundleClass {}
+
+private func DJALocalizedString(_ key: String, tableName: String? = nil, value: String = "", comment: String) -> String {
+    NSLocalizedString(key, tableName: tableName, bundle: Bundle(for: DJAStringsBundleClass.self), value: value, comment: comment)
+}
+
+"""
+        XCTAssertEqual(vendedSwiftCode, expectedOutput)
+    }
+    
+    func testItUsesTheCorrectLocalizedStringFunctionForStringsWithTheStaleExtractionState() throws {
+        givenASwiftCodeGenerator(withRootLocalisationsTreeNode: TestLocalisationsTreeNode(name: "Root",
+                                                                                          localisations: [
+                                                                                            Localisation(key: "Stale", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .stale, comment: nil, placeholders: [], previews: [
+                                                                                                Localisation.Preview(description: nil, value: "Localised")
+                                                                                            ])
+                                                                                          ],
+                                                                                          childNodes: []))
+        try whenSwiftCodeIsVended()
+        let expectedOutput =
+        """
+import Foundation
+
+public enum Root {
+    /// Localised
+    static let stale = DJALocalizedString("Stale", tableName: "Localizable", comment: "")
+}
+
+private final class DJAStringsBundleClass {}
+
+private func DJALocalizedString(_ key: String, tableName: String? = nil, value: String = "", comment: String) -> String {
+    NSLocalizedString(key, tableName: tableName, bundle: Bundle(for: DJAStringsBundleClass.self), value: value, comment: comment)
+}
+
+"""
+        XCTAssertEqual(vendedSwiftCode, expectedOutput)
+    }
+    
+    func testItUsesTheCorrectLocalizedStringFunctionForStringsWithNoExtractionState() throws {
+        givenASwiftCodeGenerator(withRootLocalisationsTreeNode: TestLocalisationsTreeNode(name: "Root",
+                                                                                          localisations: [
+                                                                                            Localisation(key: "no_extraction", tableName: "Localizable", defaultLanguageValue: nil, extractionState: nil, comment: nil, placeholders: [], previews: [
+                                                                                                Localisation.Preview(description: nil, value: "Localised")
+                                                                                            ])
+                                                                                          ],
+                                                                                          childNodes: []))
+        try whenSwiftCodeIsVended()
+        let expectedOutput =
+        """
+import Foundation
+
+public enum Root {
+    /// Localised
+    static let noExtraction = NSLocalizedString("no_extraction", tableName: "Localizable", comment: "")
+}
+
+private final class DJAStringsBundleClass {}
+
+private func DJALocalizedString(_ key: String, tableName: String? = nil, value: String = "", comment: String) -> String {
+    NSLocalizedString(key, tableName: tableName, bundle: Bundle(for: DJAStringsBundleClass.self), value: value, comment: comment)
+}
+
+"""
+        XCTAssertEqual(vendedSwiftCode, expectedOutput)
+    }
+}
+
 // MARK: - Default Value Parameter
 
 extension SwiftCodeGeneratorTests {
     func testItGeneratesTheCorrectOutputForLocalisationsWithDefaultValues() throws {
         givenASwiftCodeGenerator(withRootLocalisationsTreeNode: TestLocalisationsTreeNode(name: "Root",
                                                                                           localisations: [
-                                                                                            Localisation(key: "localisation", tableName: "Localizable", defaultLanguageValue: "Localisation", comment: nil, placeholders: [], previews: [])
+                                                                                            Localisation(key: "localisation", tableName: "Localizable", defaultLanguageValue: "Localisation", extractionState: .manual, comment: nil, placeholders: [], previews: [])
                                                                                           ],
                                                                                           childNodes: [
                                                                                             TestLocalisationsTreeNode(name: "child_one",
                                                                                                                       localisations: [
-                                                                                                                        Localisation(key: "child_one.one", tableName: "Localizable", defaultLanguageValue: "Child One", comment: nil, placeholders: [], previews: []),
-                                                                                                                        Localisation(key: "child_one.two", tableName: "Localizable", defaultLanguageValue: "Child Two", comment: nil, placeholders: [Localisation.Placeholder(name: nil, type: .object)], previews: [])
+                                                                                                                        Localisation(key: "child_one.one", tableName: "Localizable", defaultLanguageValue: "Child One", extractionState: .manual, comment: nil, placeholders: [], previews: []),
+                                                                                                                        Localisation(key: "child_one.two", tableName: "Localizable", defaultLanguageValue: "Child Two", extractionState: .manual, comment: nil, placeholders: [Localisation.Placeholder(name: nil, type: .object)], previews: [])
                                                                                                                       ],
                                                                                                                       childNodes: [])]))
         try whenSwiftCodeIsVended()
@@ -337,7 +481,7 @@ private func DJALocalizedString(_ key: String, tableName: String? = nil, value: 
     func testItGeneratesTheCorrectOutputForLocalisationsWithDefaultValuesContainingNewlines() throws {
         givenASwiftCodeGenerator(withRootLocalisationsTreeNode: TestLocalisationsTreeNode(name: "Root",
                                                                                           localisations: [
-                                                                                            Localisation(key: "localisation", tableName: "Localizable", defaultLanguageValue: "I contain a\nnewline character.", comment: nil, placeholders: [], previews: [
+                                                                                            Localisation(key: "localisation", tableName: "Localizable", defaultLanguageValue: "I contain a\nnewline character.", extractionState: .manual, comment: nil, placeholders: [], previews: [
                                                                                                 Localisation.Preview(description: nil, value: "Localised")
                                                                                             ])
                                                                                           ],
@@ -365,7 +509,7 @@ private func DJALocalizedString(_ key: String, tableName: String? = nil, value: 
     func testItGeneratesTheCorrectOutputForLocalisationsWithDefaultValuesContainingQuotationMarks() throws {
         givenASwiftCodeGenerator(withRootLocalisationsTreeNode: TestLocalisationsTreeNode(name: "Root",
                                                                                           localisations: [
-                                                                                            Localisation(key: "localisation", tableName: "Localizable", defaultLanguageValue: "I contain \"quotation marks\".", comment: nil, placeholders: [], previews: [
+                                                                                            Localisation(key: "localisation", tableName: "Localizable", defaultLanguageValue: "I contain \"quotation marks\".", extractionState: .manual, comment: nil, placeholders: [], previews: [
                                                                                                 Localisation.Preview(description: nil, value: "Localised")
                                                                                             ])
                                                                                           ],
@@ -397,10 +541,10 @@ extension SwiftCodeGeneratorTests {
     func testItIncludesTheLocalisationCommentsInTheCallToTheLocalizedStringFunctionAndDocumentation() throws {
         givenASwiftCodeGenerator(withRootLocalisationsTreeNode: TestLocalisationsTreeNode(name: "Root",
                                                                                           localisations: [
-                                                                                            Localisation(key: "localisation_one", tableName: "Localizable", defaultLanguageValue: nil, comment: "Comment One", placeholders: [], previews: [
+                                                                                            Localisation(key: "localisation_one", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .manual, comment: "Comment One", placeholders: [], previews: [
                                                                                                 Localisation.Preview(description: nil, value: "Localised One")
                                                                                             ]),
-                                                                                            Localisation(key: "localisation_two", tableName: "Localizable", defaultLanguageValue: nil, comment: "Comment Two", placeholders: [], previews: [
+                                                                                            Localisation(key: "localisation_two", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .manual, comment: "Comment Two", placeholders: [], previews: [
                                                                                                 Localisation.Preview(description: nil, value: "Localised Two")
                                                                                             ])
                                                                                           ],
@@ -437,7 +581,7 @@ private func DJALocalizedString(_ key: String, tableName: String? = nil, value: 
     func testItProducesTheCorrectCommentWhenTheSourceFileCommentContainsNewlines() throws {
         givenASwiftCodeGenerator(withRootLocalisationsTreeNode: TestLocalisationsTreeNode(name: "Root",
                                                                                           localisations: [
-                                                                                            Localisation(key: "localisation", tableName: "Localizable", defaultLanguageValue: nil, comment: "Comment\nwith\nnewlines", placeholders: [], previews: [
+                                                                                            Localisation(key: "localisation", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .manual, comment: "Comment\nwith\nnewlines", placeholders: [], previews: [
                                                                                                 Localisation.Preview(description: nil, value: "Localised")
                                                                                             ])
                                                                                           ],
@@ -472,7 +616,7 @@ extension SwiftCodeGeneratorTests {
     func testItProducesTheCorrectDocumentationCommentForLocalisationPreviewsWithADescription() throws {
         givenASwiftCodeGenerator(withRootLocalisationsTreeNode: TestLocalisationsTreeNode(name: "Root",
                                                                                           localisations: [
-                                                                                            Localisation(key: "localisation", tableName: "Localizable", defaultLanguageValue: nil, comment: nil, placeholders: [], previews: [
+                                                                                            Localisation(key: "localisation", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .manual, comment: nil, placeholders: [], previews: [
                                                                                                 Localisation.Preview(description: "Description", value: "Value")
                                                                                             ])
                                                                                           ],
@@ -501,7 +645,7 @@ private func DJALocalizedString(_ key: String, tableName: String? = nil, value: 
     func testItProducesTheCorrectDocumentationCommentsForLocalisationsWithMultiplePreviews() throws {
         givenASwiftCodeGenerator(withRootLocalisationsTreeNode: TestLocalisationsTreeNode(name: "Root",
                                                                                           localisations: [
-                                                                                            Localisation(key: "localisation", tableName: "Localizable", defaultLanguageValue: nil, comment: nil, placeholders: [], previews: [
+                                                                                            Localisation(key: "localisation", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .manual, comment: nil, placeholders: [], previews: [
                                                                                                 Localisation.Preview(description: "Description One", value: "Value One"),
                                                                                                 Localisation.Preview(description: "Description Two", value: "Value Two"),
                                                                                                 Localisation.Preview(description: "Description Three", value: "Value Three"),
@@ -540,7 +684,7 @@ private func DJALocalizedString(_ key: String, tableName: String? = nil, value: 
     func testItProducesTheCorrectDocumentationCommentsForLocalisationsWithMultiplePreviewsAndAComment() throws {
         givenASwiftCodeGenerator(withRootLocalisationsTreeNode: TestLocalisationsTreeNode(name: "Root",
                                                                                           localisations: [
-                                                                                            Localisation(key: "localisation", tableName: "Localizable", defaultLanguageValue: nil, comment: "I have multiple previews", placeholders: [], previews: [
+                                                                                            Localisation(key: "localisation", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .manual, comment: "I have multiple previews", placeholders: [], previews: [
                                                                                                 Localisation.Preview(description: "Description One", value: "Value One"),
                                                                                                 Localisation.Preview(description: "Description Two", value: "Value Two"),
                                                                                                 Localisation.Preview(description: "Description Three", value: "Value Three"),
@@ -582,7 +726,7 @@ private func DJALocalizedString(_ key: String, tableName: String? = nil, value: 
     func testItProducesTheCorrectDocumentationCommentsForLocalisationsWithPreviewsContainingNewlines() throws {
         givenASwiftCodeGenerator(withRootLocalisationsTreeNode: TestLocalisationsTreeNode(name: "Root",
                                                                                           localisations: [
-                                                                                            Localisation(key: "localisation", tableName: "Localizable", defaultLanguageValue: nil, comment: nil, placeholders: [], previews: [
+                                                                                            Localisation(key: "localisation", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .manual, comment: nil, placeholders: [], previews: [
                                                                                                 Localisation.Preview(description: nil, value: "Value\n\nOne")
                                                                                             ])
                                                                                           ],
@@ -614,7 +758,7 @@ extension SwiftCodeGeneratorTests {
     func testItProducesTheCorrectOutputWhenACustomFormattingConfigurationIsSpecified() throws {
         givenASwiftCodeGenerator(withRootLocalisationsTreeNode: TestLocalisationsTreeNode(name: "Root",
                                                                                           localisations: [
-                                                                                            Localisation(key: "localisation", tableName: "Localizable", defaultLanguageValue: nil, comment: nil, placeholders: [], previews: [
+                                                                                            Localisation(key: "localisation", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .manual, comment: nil, placeholders: [], previews: [
                                                                                                 Localisation.Preview(description: nil, value: "Localisation")
                                                                                             ])
                                                                                           ],


### PR DESCRIPTION
When a localised string has been extracted automatically by Xcode from source code or a XIB file, it will also be removed from the String Catalog if the origin of the extraction is removed from the source code / XIB file. If the source code is modified to use the constants generated by DJAStrings, this will cause Xcode to remove the localisation from the String Catalog, resulting in the constant no longer being generated, and a build failure will result.

DJAStrings will now handle automatically extracted strings differently, and will generate code to access them using the `NSLocalizedString` function directly, rather than wrapping its call in the `DJALocalizedString` function. This means that Xcode still has a call to `NSLocalizedString` that it can scan in order to pick up the localisation key, and will therefore not remove it from the String Catalog when the original call to `NSLocalizedString` is replaced with a DJAStrings-generated constant.