### PR TITLE
Fixed #11: Invalid Swift Syntax When Keys Contain Dashes

### DIFF
--- a/Sources/String+Extensions.swift
+++ b/Sources/String+Extensions.swift
@@ -65,14 +65,14 @@ extension String {
     ]
     
     func camelCased() -> String {
-        components(separatedBy: "_").enumerated().map{ element -> String in
+        components(separatedBy: .keyComponentSeparators).enumerated().map{ element -> String in
             let token = element.element
             return firstCharacter(forToken: token, atIndex: element.offset) + token.dropFirst()
         }.joined()
     }
     
     func titleCased() -> String {
-        components(separatedBy: "_").enumerated().map { element -> String in
+        components(separatedBy: .keyComponentSeparators).enumerated().map { element -> String in
             let token = element.element
             return token.prefix(1).uppercased() + token.dropFirst()
         }.joined()
@@ -99,4 +99,8 @@ extension String {
             return token.prefix(1).uppercased()
         }
     }
+}
+
+private extension CharacterSet {
+    static let keyComponentSeparators = CharacterSet.whitespacesAndNewlines.union(["_", "-", "—"])
 }

--- a/Tests/SwiftCodeGeneratorTests.swift
+++ b/Tests/SwiftCodeGeneratorTests.swift
@@ -366,6 +366,90 @@ private func DJALocalizedString(_ key: String, tableName: String? = nil, value: 
 """
         XCTAssertEqual(vendedSwiftCode, expectedOutput)
     }
+    
+    func testItProducesTheCorrectOutputForKeysContainingDashes() throws {
+        givenASwiftCodeGenerator(withRootLocalisationsTreeNode: TestLocalisationsTreeNode(name: "Root",
+                                                                                          localisations: [
+                                                                                            Localisation(key: "key-with-dashes", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .manual, comment: nil, placeholders: [], previews: [
+                                                                                                Localisation.Preview(description: nil, value: "key-with-dashes")
+                                                                                            ])
+                                                                                          ],
+                                                                                          childNodes: []))
+        try whenSwiftCodeIsVended()
+        let expectedOutput =
+        """
+import Foundation
+
+public enum Root {
+    /// key-with-dashes
+    static let keyWithDashes = DJALocalizedString("key-with-dashes", tableName: "Localizable", comment: "")
+}
+
+private final class DJAStringsBundleClass {}
+
+private func DJALocalizedString(_ key: String, tableName: String? = nil, value: String = "", comment: String) -> String {
+    NSLocalizedString(key, tableName: tableName, bundle: Bundle(for: DJAStringsBundleClass.self), value: value, comment: comment)
+}
+
+"""
+        XCTAssertEqual(vendedSwiftCode, expectedOutput)
+    }
+    
+    func testItProducesTheCorrectOutputForKeysContainingEMDashes() throws {
+        givenASwiftCodeGenerator(withRootLocalisationsTreeNode: TestLocalisationsTreeNode(name: "Root",
+                                                                                          localisations: [
+                                                                                            Localisation(key: "key—with—em—dashes", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .manual, comment: nil, placeholders: [], previews: [
+                                                                                                Localisation.Preview(description: nil, value: "key—with—em—dashes")
+                                                                                            ])
+                                                                                          ],
+                                                                                          childNodes: []))
+        try whenSwiftCodeIsVended()
+        let expectedOutput =
+        """
+import Foundation
+
+public enum Root {
+    /// key—with—em—dashes
+    static let keyWithEmDashes = DJALocalizedString("key—with—em—dashes", tableName: "Localizable", comment: "")
+}
+
+private final class DJAStringsBundleClass {}
+
+private func DJALocalizedString(_ key: String, tableName: String? = nil, value: String = "", comment: String) -> String {
+    NSLocalizedString(key, tableName: tableName, bundle: Bundle(for: DJAStringsBundleClass.self), value: value, comment: comment)
+}
+
+"""
+        XCTAssertEqual(vendedSwiftCode, expectedOutput)
+    }
+    
+    func testItProducesTheCorrectOutputForKeysContainingSpaces() throws {
+        givenASwiftCodeGenerator(withRootLocalisationsTreeNode: TestLocalisationsTreeNode(name: "Root",
+                                                                                          localisations: [
+                                                                                            Localisation(key: "key with  spaces", tableName: "Localizable", defaultLanguageValue: nil, extractionState: .manual, comment: nil, placeholders: [], previews: [
+                                                                                                Localisation.Preview(description: nil, value: "key with  spaces")
+                                                                                            ])
+                                                                                          ],
+                                                                                          childNodes: []))
+        try whenSwiftCodeIsVended()
+        let expectedOutput =
+        """
+import Foundation
+
+public enum Root {
+    /// key with  spaces
+    static let keyWithSpaces = DJALocalizedString("key with  spaces", tableName: "Localizable", comment: "")
+}
+
+private final class DJAStringsBundleClass {}
+
+private func DJALocalizedString(_ key: String, tableName: String? = nil, value: String = "", comment: String) -> String {
+    NSLocalizedString(key, tableName: tableName, bundle: Bundle(for: DJAStringsBundleClass.self), value: value, comment: comment)
+}
+
+"""
+        XCTAssertEqual(vendedSwiftCode, expectedOutput)
+    }
 }
 
 // MARK: - Swift Keywords


### PR DESCRIPTION
Fixes an issue where string keys containing dashes caused code generation to fail.