### PR TITLE
Don't Generate Symbols for Strings Whose Keys Contain Markdown

### DIFF
--- a/Sources/LocalisationGroup.swift
+++ b/Sources/LocalisationGroup.swift
@@ -345,9 +345,13 @@ private extension String {
         let allFormatCharacters = Localisation.Placeholder.DataType.allCases.flatMap { $0.formatCharacters }
         return try! Regex("[%](.*?)[\(allFormatCharacters)]")
     }()
+    private static let markdownRegex = #/\[.+]\((?:.*)\)/#
     
     var isSuitableSwiftSymbol: Bool {
-        rangeOfCharacter(from: .whitespaces) == nil
+        if rangeOfCharacter(from: .whitespaces) != nil {
+            return false
+        }
+        return firstMatch(of: Self.markdownRegex) == nil
     }
     
     var placeholders: [Localisation.Placeholder] {

--- a/Tests/LocalisationGroupTests.swift
+++ b/Tests/LocalisationGroupTests.swift
@@ -307,6 +307,17 @@ extension LocalisationGroupTests {
     }
 }
 
+// MARK: - Markdown
+
+extension LocalisationGroupTests {
+    func testItDoesNotProduceLocalisationsForStringsWhoseKeysContainMarkdown() throws {
+        givenALocalisationGroup()
+        try whenAParsedStringsDocumentIsApplied(withFilename: "Markdown Key Strings")
+        XCTAssertTrue(localisationGroup.localisations.isEmpty)
+        XCTAssertTrue(localisationGroup.childGroups.isEmpty)
+    }
+}
+
 // MARK: - Previews
 
 extension LocalisationGroupTests {

--- a/Tests/Resources/XCStrings Files/Markdown Key Strings.xcstrings
+++ b/Tests/Resources/XCStrings Files/Markdown Key Strings.xcstrings
@@ -1,0 +1,24 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "[just-a-link](https://darjeelingsteve.com)" : {
+      "extractionState" : "manual"
+    },
+    "^[Fast & Delicious](rainbow: 'extreme') Food" : {
+      "extractionState" : "manual"
+    },
+    "Add ^[%lld item](inflect: true) to cart" : {
+      "extractionState" : "manual"
+    },
+    "I contain ![an image](https://darjeelingsteve.com/articles/images/externallocalisations01.png)" : {
+      "extractionState" : "manual"
+    },
+    "I contain [a link](https://darjeelingsteve.com)" : {
+      "extractionState" : "manual"
+    },
+    "Zoom ^[0.5](formatNumber: true)" : {
+      "extractionState" : "manual"
+    }
+  },
+  "version" : "1.0"
+}


### PR DESCRIPTION
Fixes #15.